### PR TITLE
Build fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ envPaths
 configure/*.local
 !configure/ExampleRELEASE.local
 **/O.*
+O.*
+make.log

--- a/arrayPerformance/src/Makefile
+++ b/arrayPerformance/src/Makefile
@@ -17,28 +17,28 @@ LIBSRCS += longArrayPut.cpp
 
 PROD_HOST += arrayPerformanceMain
 arrayPerformanceMain_SRCS += arrayPerformanceMain.cpp
-arrayPerformanceMain_LIBS += pvDatabase pvAccess pvData Com
 arrayPerformanceMain_LIBS += pvDatabaseExample
+arrayPerformanceMain_LIBS += pvDatabase pvAccess pvData Com
 
 PROD_HOST += longArrayMonitorMain
 longArrayMonitorMain_SRCS += longArrayMonitorMain.cpp
-longArrayMonitorMain_LIBS += pvDatabase pvAccess pvData Com
 longArrayMonitorMain_LIBS += pvDatabaseExample
+longArrayMonitorMain_LIBS += pvDatabase pvAccess pvData Com
 
 PROD_HOST += longArrayGetMain
 longArrayGetMain_SRCS += longArrayGetMain.cpp
-longArrayGetMain_LIBS += pvDatabase pvAccess pvData Com
 longArrayGetMain_LIBS += pvDatabaseExample
+longArrayGetMain_LIBS += pvDatabase pvAccess pvData Com
 
 PROD_HOST += longArrayPutMain
 longArrayPutMain_SRCS += longArrayPutMain.cpp
-longArrayPutMain_LIBS += pvDatabase pvAccess pvData Com
 longArrayPutMain_LIBS += pvDatabaseExample
+longArrayPutMain_LIBS += pvDatabase pvAccess pvData Com
 
 PROD_HOST += vectorPerformanceMain
 vectorPerformanceMain_SRCS += vectorPerformanceMain.cpp
-vectorPerformanceMain_LIBS += pvDatabase pvAccess pvData Com
 vectorPerformanceMain_LIBS += pvDatabaseExample
+vectorPerformanceMain_LIBS += pvDatabase pvAccess pvData Com
 
 
 include $(TOP)/configure/RULES

--- a/database/configure/RELEASE
+++ b/database/configure/RELEASE
@@ -1,4 +1,4 @@
-# pvDatabaseCPP/example RELEASE - Location of external support modules
+# pvExampleTestCPP/database RELEASE - Location of external support modules
 #
 # IF YOU CHANGE this file or any file it includes you must
 # subsequently do a "gnumake rebuild" in the application's
@@ -24,19 +24,17 @@
 #   PVCOMMON = /path/to/epics/pvCommonCPP
 #   EPICS_BASE = /path/to/epics/base
 
-# If this example is built in a directory under pvDatabaseCPP,
+# If this example is built in a directory under pvExampleTestCPP,
 # use the following definitions:
 
 
 -include $(TOP)/configure/RELEASE.local
 -include $(TOP)/../configure/RELEASE.local
 -include $(TOP)/../../RELEASE.local
+PVEXAMPLETEST=$(TOP)/..
 
-# If you copied this example from pvDatabaseCPP to be built as a
+# If you copied this example from pvExampleTestCPP to be built as a
 # standalone TOP, adjust and use the following definitions:
 
-#PVDATABASETEST = /path/to/epics/pvDatabaseCPP/testTop
-#PVDATABASE = /path/to/epics/pvDatabaseCPP
-
 #-include $(TOP)/../RELEASE.local
-#-include $(TOP)/configure/RELEASE.local
+#PVEXAMPLETEST    = /path/to/epics/pvExampleTestCPP

--- a/database/ioc/src/Makefile
+++ b/database/ioc/src/Makefile
@@ -27,6 +27,7 @@ exampleDatabase_SRCS_vxWorks += -nil-
 exampleDatabase_OBJS_vxWorks += $(EPICS_BASE_BIN)/vxComLibrary
 
 exampleDatabase_LIBS += exampleDatabase
+exampleDatabase_LIBS += powerSupply
 exampleDatabase_LIBS += pvDatabase
 exampleDatabase_LIBS += pvaSrv
 exampleDatabase_LIBS += pvAccess

--- a/exampleClient/src/Makefile
+++ b/exampleClient/src/Makefile
@@ -10,6 +10,7 @@ examplePvaClientProcess_SRCS += examplePvaClientProcess.cpp
 examplePvaClientProcess_LIBS += pvaClient
 examplePvaClientProcess_LIBS += pvAccess
 examplePvaClientProcess_LIBS += pvData
+examplePvaClientProcess_LIBS += ca
 examplePvaClientProcess_LIBS += Com
 
 PROD_HOST += examplePvaClientGet
@@ -17,6 +18,7 @@ examplePvaClientGet_SRCS += examplePvaClientGet.cpp
 examplePvaClientGet_LIBS += pvaClient
 examplePvaClientGet_LIBS += pvAccess
 examplePvaClientGet_LIBS += pvData
+examplePvaClientGet_LIBS += ca
 examplePvaClientGet_LIBS += Com
 
 PROD_HOST += examplePvaClientPut
@@ -24,6 +26,7 @@ examplePvaClientPut_SRCS += examplePvaClientPut.cpp
 examplePvaClientPut_LIBS += pvaClient
 examplePvaClientPut_LIBS += pvAccess
 examplePvaClientPut_LIBS += pvData
+examplePvaClientPut_LIBS += ca
 examplePvaClientPut_LIBS += Com
 
 PROD_HOST += examplePvaClientMonitor
@@ -31,20 +34,25 @@ examplePvaClientMonitor_SRCS += examplePvaClientMonitor.cpp
 examplePvaClientMonitor_LIBS += pvaClient
 examplePvaClientMonitor_LIBS += pvAccess
 examplePvaClientMonitor_LIBS += pvData
+examplePvaClientMonitor_LIBS += ca
 examplePvaClientMonitor_LIBS += Com
 
 PROD_HOST += examplePvaClientMultiDouble
 examplePvaClientMultiDouble_SRCS += examplePvaClientMultiDouble.cpp
 examplePvaClientMultiDouble_LIBS += pvaClient
 examplePvaClientMultiDouble_LIBS += pvAccess
+examplePvaClientMultiDouble_LIBS += nt
 examplePvaClientMultiDouble_LIBS += pvData
+examplePvaClientMultiDouble_LIBS += ca
 examplePvaClientMultiDouble_LIBS += Com
 
 PROD_HOST += examplePvaClientNTMulti
 examplePvaClientNTMulti_SRCS += examplePvaClientNTMulti.cpp
 examplePvaClientNTMulti_LIBS += pvaClient
 examplePvaClientNTMulti_LIBS += pvAccess
+examplePvaClientNTMulti_LIBS += nt
 examplePvaClientNTMulti_LIBS += pvData
+examplePvaClientNTMulti_LIBS += ca
 examplePvaClientNTMulti_LIBS += Com
 
 PROD_HOST += helloWorldRPC
@@ -61,6 +69,7 @@ helloWorldPutGet_LIBS += pvaClient
 helloWorldPutGet_LIBS += pvAccess
 helloWorldPutGet_LIBS += nt
 helloWorldPutGet_LIBS += pvData
+helloWorldPutGet_LIBS += ca
 helloWorldPutGet_LIBS += Com
 
 #===========================

--- a/examplePowerSupply/src/Makefile
+++ b/examplePowerSupply/src/Makefile
@@ -10,14 +10,14 @@ include $(TOP)/configure/CONFIG
 #
 
 
-PROD_HOST += powerSupplyMain
-powerSupplyMain_SRCS += powerSupplyMain.cpp
+#PROD_HOST += powerSupplyMain
+#powerSupplyMain_SRCS += powerSupplyMain.cpp
 
-powerSupplyMain_LIBS += pvDatabase
-powerSupplyMain_LIBS += pvAccess
-powerSupplyMain_LIBS += pvData
-powerSupplyMain_LIBS += Com
-powerSupplyMain_LIBS += powerSupply
+#powerSupplyMain_LIBS += pvDatabase
+#powerSupplyMain_LIBS += pvAccess
+#powerSupplyMain_LIBS += pvData
+#powerSupplyMain_LIBS += Com
+#powerSupplyMain_LIBS += powerSupply
 
 #===========================
 

--- a/exampleServer/src/Makefile
+++ b/exampleServer/src/Makefile
@@ -23,13 +23,13 @@ exampleServer_LIBS += pvData
 exampleServer_LIBS += Com
 exampleServer_LIBS += $(EPICS_BASE_IOC_LIBS)
 
-PROD_HOST += exampleServerMain
-exampleServerMain_SRCS += exampleServerMain.cpp
-exampleServerMain_LIBS += exampleServer
-exampleServerMain_LIBS += pvDatabase
-exampleServerMain_LIBS += pvAccess
-exampleServerMain_LIBS += pvData
-exampleServerMain_LIBS += Com
+#PROD_HOST += exampleServerMain
+#exampleServerMain_SRCS += exampleServerMain.cpp
+#exampleServerMain_LIBS += exampleServer
+#exampleServerMain_LIBS += pvDatabase
+#exampleServerMain_LIBS += pvAccess
+#exampleServerMain_LIBS += pvData
+#exampleServerMain_LIBS += Com
 
 #===========================
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -33,7 +33,7 @@ pvaClientTestPutGet_SRCS = pvaClientTestPutGet
 testHarness_SRCS += pvaClientTestPutGet.cpp 
 TESTS += pvaClientTestPutGet
 
-PROD_LIBS += pvaClient pvAccess nt pvData Com
+PROD_LIBS += pvaClient pvAccess nt pvData ca Com
 
 testHarness_SRCS += pvaClientAllTests.c
 
@@ -41,10 +41,10 @@ PROD_vxWorks = vxTestHarness
 vxTestHarness_SRCS += $(testHarness_SRCS)
 TESTSPEC_vxWorks = vxTestHarness.$(MUNCH_SUFFIX); pvaClientAllTests
 
-PROD_RTEMS += rtemsTestHarness
-rtemsTestHarness_SRCS += rtemsTestHarness.c rtemsConfig.c
-rtemsTestHarness_SRCS += $(testHarness_SRCS)
-TESTSPEC_RTEMS = rtemsTestHarness.$(MUNCH_SUFFIX); pvaClientAllTests
+# PROD_RTEMS += rtemsTestHarness
+# rtemsTestHarness_SRCS += rtemsTestHarness.c rtemsConfig.c
+# rtemsTestHarness_SRCS += $(testHarness_SRCS)
+# TESTSPEC_RTEMS = rtemsTestHarness.$(MUNCH_SUFFIX); pvaClientAllTests
 
 TESTSCRIPTS_HOST += $(TESTS:%=%.t)
 

--- a/test/pvaClientTestPutGetMonitor.cpp
+++ b/test/pvaClientTestPutGetMonitor.cpp
@@ -29,7 +29,7 @@ class MyMonitor : public PvaClientMonitorRequester
 public:
     MyMonitor() {}
     virtual ~MyMonitor() {}
-    virtual void event(PvaClientMonitorPtr monitor)
+    virtual void event(PvaClientMonitorPtr const & monitor)
     {
         testDiag("monitor event");
         PvaClientMonitorDataPtr pvaData = monitor->getData();


### PR DESCRIPTION
Fixed build problems w/ missing and out of order LIB directives.
Sets PVEXAMPLETEST macro to TOP/.. so powerSupply.h and libpowerSupply.\* can be found.
Disabled build of broken examples that use non-existent ContextLocal class.
Added an O.\* line to fix gitignore for older git versions that don't support *_/O._
Also ignore *.log files
Fixed arg type to const & for virtual void function event
